### PR TITLE
Bug wrong file path for c binary

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "dependencies": {
     "bindings": "~1.3.0",
-    "debug": "3",
+    "debug": "4.1.1",
     "ffi": "^2.1.0",
     "nan": "2",
     "ref": "1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tweetnacl-nodewrap",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "description": "Nodejs wraper for TweetNaCl cryptographic library",
   "main": "src/js/nacl.js",
   "directories": {

--- a/src/js/tweetnacl_wrapper.js
+++ b/src/js/tweetnacl_wrapper.js
@@ -6,12 +6,7 @@ var ffi = require('ffi');
 var typedef = require('./tweetnacl_typedef.js')();
 var path = require('path');
 var crypto = require('crypto');
-var libPath = '';
-if (ffi.LIB_EXT === '.dll') {
-  libPath = path.resolve(__dirname.replace('\\js', '\\'), 'c\\libtweetnacl');
-} else {
-  libPath = path.resolve(__dirname.replace('/js', '/'), 'c/libtweetnacl');
-}
+var libPath = path.resolve(__dirname, '..', 'c', 'libtweetnacl');
 
 module.exports = function() {
   var libencrypt = ffi.Library(libPath, {


### PR DESCRIPTION
Problem: Any path with "/js" will get the wrong filepath to the binary because that string is replaced.
Solution: Use resolver to set the filepath to the binary.